### PR TITLE
Fix custom string types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # azure-golang-iot-hub
 
-Experimental (minimalistic) Azure IoT Hub client in Go (HTTPS only)
+Experimental (minimalistic) Azure IoT Hub client in Go (HTTPS only).
+This has been tested using Go version 1.8.5 on a linux/amd64 architecture.
 
 ## TODO
 
@@ -25,4 +26,3 @@ or...
 export CONNECTION_STRING='HostName=myhub.azure-devices.net;DeviceId=testdevice;SharedAccessKey=SxiN78h8tdN3yQXMBhmV193ZxKWBHhmJptGcvheA3dg='
 make run
 ```
-

--- a/iothubHttp.go
+++ b/iothubHttp.go
@@ -24,10 +24,10 @@ const (
 	apiVersion         string = "2016-11-14"
 )
 
-type sharedAccessKey = string
-type sharedAccessKeyName = string
-type hostName = string
-type deviceID = string
+type sharedAccessKey string
+type sharedAccessKeyName string
+type hostName string
+type deviceID string
 
 // IotHubHTTPClient is a simple client to connect to Azure IoT Hub
 type IotHubHTTPClient struct {
@@ -61,12 +61,12 @@ func tryGetKeyByName(v url.Values, key string) string {
 }
 
 // NewIotHubHTTPClient is a constructor of IutHubClient
-func NewIotHubHTTPClient(hostName string, sharedAccessKeyName string, sharedAccessKey string, deviceID string) *IotHubHTTPClient {
+func NewIotHubHTTPClient(hostNameStr string, sharedAccessKeyNameStr string, sharedAccessKeyStr string, deviceIDStr string) *IotHubHTTPClient {
 	return &IotHubHTTPClient{
-		sharedAccessKeyName: sharedAccessKeyName,
-		sharedAccessKey:     sharedAccessKey,
-		hostName:            hostName,
-		deviceID:            deviceID,
+		sharedAccessKeyName: sharedAccessKeyName(sharedAccessKeyNameStr),
+		sharedAccessKey:     sharedAccessKey(sharedAccessKeyStr),
+		hostName:            hostName(hostNameStr),
+		deviceID:            deviceID(deviceIDStr),
 		client: &http.Client{
 			Transport: &http.Transport{
 				MaxIdleConnsPerHost: maxIdleConnections,
@@ -83,7 +83,7 @@ func NewIotHubHTTPClientFromConnectionString(connectionString string) (*IotHubHT
 		return nil, err
 	}
 
-	return NewIotHubHTTPClient(h, kn, k, d), nil
+	return NewIotHubHTTPClient(string(h), string(kn), string(k), string(d)), nil
 }
 
 // IsDevice tell either device id was specified when client created.
@@ -147,7 +147,7 @@ func (c *IotHubHTTPClient) buildSasToken(uri string) string {
 
 	toSign := encodedURI + "\n" + strconv.FormatInt(timestamp, 10)
 
-	binKey, _ := base64.StdEncoding.DecodeString(c.sharedAccessKey)
+	binKey, _ := base64.StdEncoding.DecodeString(string(c.sharedAccessKey))
 	mac := hmac.New(sha256.New, []byte(binKey))
 	mac.Write([]byte(toSign))
 


### PR DESCRIPTION
This compiles on go version go1.8.5 linux/amd64.

Nice `main.go` example by the way. I was thinking at increasing the test coverage by using that code in `main.go` to make some assertions (using the testing functions from the standard library, no new dependencies).

Cheers 